### PR TITLE
fix: properly ignore files in docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 # .dockerignore
-*/test_*
+**/test_*.py
+**/__pycache__/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated file exclusion patterns to more precisely ignore Python test files and all `__pycache__` directories during Docker builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->