### PR TITLE
fix: varible might_be_hosts_csv only accept files named after *.csv

### DIFF
--- a/.github/workflows/ananta.yml
+++ b/.github/workflows/ananta.yml
@@ -46,7 +46,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/checkout@v4
 
-      - name: Build the latest variant to the local docker daemon
+      - name: Build and load Docker image to local daemon
         uses: docker/build-push-action@v6
         with:
           load: true
@@ -58,7 +58,7 @@ jobs:
           docker save -o "ananta.${{ matrix.variant }}.tar" "${{ env.ananta_repo }}:${{ matrix.variant }}"
 
       - name: Smoke Test
-        if: matrix.variant == 'latest'
+        if: ${{ matrix.variant == 'latest' }}
         run: |
           sudo apt-get update -qq \
               && sudo apt-get -y install \

--- a/.github/workflows/ananta.yml
+++ b/.github/workflows/ananta.yml
@@ -44,8 +44,40 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - uses: actions/checkout@v4
+
+      - name: Build the latest variant to the local docker daemon
+        uses: docker/build-push-action@v6
+        with:
+          load: true
+          tags: ${{ env.ananta_repo }}:${{ matrix.variant }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Save the docker images as tarball
+        run: |
+          docker save -o "ananta.${{ matrix.variant }}.tar" "${{ env.ananta_repo }}:${{ matrix.variant }}"
+
+      - name: Smoke Test
+        if: matrix.variant == 'latest'
+        run: |
+          sudo apt-get update -qq \
+              && sudo apt-get -y install \
+                  openssh-client openssh-server \
+              && sudo systemctl start ssh.service
+
+          mkdir -p "${HOME}/.ssh/"
+          ssh-keygen -t ed25519 -N '' -f "${HOME}/.ssh/ed25519"
+          cat "${HOME}/.ssh/ed25519.pub" >> "${HOME}/.ssh/authorized_keys"
+          cat << EEOOFF > "${HOME}/.ssh/config"
+          Host localhost
+              Hostname 127.0.0.1
+              User $(whoami)
+          EEOOFF
+
+          today=$(date +%Y-%m-%d)
+          docker tag "${{ env.ananta_repo }}:latest" "${{ env.ananta_repo }}:${today}"
+          bash -x installer/dummy_ananta.sh whoami
+
       -
         name: Build and push
         uses: docker/build-push-action@v6
@@ -56,15 +88,9 @@ jobs:
           tags: ${{ env.ananta_repo }}:${{ matrix.variant }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-      -
-        name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.ananta_repo }}:${{ matrix.variant }} \
-              | grep -Po '[^ \r\n\t\v]+@sha256:[a-z0-9]+' | xargs -r -t -n 1 docker buildx imagetools inspect --raw
       -
         name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.30.0
         with:
-          image-ref: "${{ env.ananta_repo }}:${{ matrix.variant }}"
+          input: "ananta.${{ matrix.variant }}.tar"
           format: 'table'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,8 @@
 name: Linter
+permissions:
+  contents: read
+  packages: write
+  id-token: write
 
 on:
     push:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,4 +1,8 @@
 name: Unittest
+permissions:
+  contents: read
+  packages: write
+  id-token: write
 
 on:
   push:

--- a/installer/dummy_ananta.sh
+++ b/installer/dummy_ananta.sh
@@ -52,10 +52,10 @@ In case you want to specify an existing hosts.csv,
         inputs+=("$1" "$2")
         shift 2
         ;;
-    [!-]*.csv)
+    [!-]*.[cC][sS][vV])
         might_be_hosts_csv="$1"
         shift
-        # Stop processing remaining arguments
+        # Capture all remaining args (commands) in `append` and exit the parse loop
         append=("$@")
         break
         ;;

--- a/installer/dummy_ananta.sh
+++ b/installer/dummy_ananta.sh
@@ -52,7 +52,7 @@ In case you want to specify an existing hosts.csv,
         inputs+=("$1" "$2")
         shift 2
         ;;
-    [!-]*)
+    [!-]*.csv)
         might_be_hosts_csv="$1"
         shift
         # Stop processing remaining arguments


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved argument detection to only recognize files ending with `.csv` as valid hosts CSV files during installation.
- **Chores**
  - Enhanced GitHub Actions workflows with explicit permissions settings.
  - Updated CI workflow to build, cache, and test Docker images more efficiently, including a new smoke test for the latest variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->