### PR TITLE
chore: eliminate dependency on coreutils (realpath)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -e -o pipefail
 cd /home/nonroot/.ssh/ || exit 1
 ananta_args=()
 ssh_command=()
-hosts_file="/home/nonroot/_autogen_hosts.csv"
+hosts_csv="/home/nonroot/_autogen_hosts.csv"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -37,14 +37,14 @@ done
 
 if [[ -n "$_HOSTS_CSV" ]]; then
     # Modify the hosts.csv path to be under /home/nonroot/
-    hosts_file="/home/nonroot/$(basename "$_HOSTS_CSV")"
+    hosts_csv="/home/nonroot/$(basename "$_HOSTS_CSV")"
 else
     echo "INFO: Will try to generate one using the SSH config..."
     /home/nonroot/sshconfig_to_ananta/main.py \
         --ssh /home/nonroot/.ssh/config \
         --relocate /home/nonroot/.ssh/ \
-        "$hosts_file"
+        "$hosts_csv"
 fi
 
 # Run the ananta command with the modified arguments
-exec catatonit -- ananta "${ananta_args[@]}" "$hosts_file" "${ssh_command[@]}"
+exec catatonit -- ananta "${ananta_args[@]}" "$hosts_csv" "${ssh_command[@]}"

--- a/installer/dummy_ananta.sh
+++ b/installer/dummy_ananta.sh
@@ -58,7 +58,7 @@ In case you want to specify an existing hosts.csv,
         shift 2
         ;;
     [!-]*.[cC][sS][vV])
-        might_be_hosts_csv="$1"
+        hosts_csv="$1"
         shift
         ;;
     *)
@@ -75,12 +75,12 @@ done
 if [[ "$UID" -ne 65532 ]]; then
     docker_run_args+=('--user' 'root')
 fi
-if [[ -n "$might_be_hosts_csv" ]]; then
-    absolute_hosts_csv="$(realpath "$might_be_hosts_csv")"
-    if [[ -f "$absolute_hosts_csv" ]]; then
-        docker_run_args+=('--volume' "${absolute_hosts_csv}:/home/nonroot/$(basename "$absolute_hosts_csv"):ro")
+if [[ -n "$hosts_csv" ]]; then
+    if [[ -f "$hosts_csv" ]]; then
+        docker_run_args+=('--volume' "${hosts_csv}:/home/nonroot/$(basename "$hosts_csv"):ro")
     else
-        ssh_command=("$might_be_hosts_csv" "${ssh_command[@]}")
+        echo "ERROR: ${hosts_csv} does not exist or is not a regular file."
+        exit 1
     fi
 fi
 
@@ -96,4 +96,4 @@ docker run --rm \
     --cpu-shares 512 --memory 512M --memory-swap 512M \
     --security-opt no-new-privileges \
     icecodexi/ananta:latest \
-        "${ananta_args[@]}" "$absolute_hosts_csv" "${ssh_command[@]}"
+        "${ananta_args[@]}" "$hosts_csv" "${ssh_command[@]}"


### PR DESCRIPTION
throw an error when hosts.csv does not exist, instead of regard it as
part of SSH command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated variable names related to the hosts CSV file for improved consistency across scripts.
  - Adjusted file path handling and validation in script logic for better clarity.
- **Bug Fixes**
  - Improved error handling when the specified hosts CSV file does not exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->