### PR TITLE
fix: default value of relocate is not empty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sshconfig_to_ananta"
-version = "2.1.0"
+version = "2.1.1"
 description = "Convert SSH config to Ananta hosts format (CSV or TOML)"
 authors = [
     { name = "IceCodeNew" },

--- a/src/sshconfig_to_ananta/ananta_host.py
+++ b/src/sshconfig_to_ananta/ananta_host.py
@@ -71,7 +71,7 @@ class AnantaHost(Mapping[str, Any]):
             key_path_obj = relocate / Path(key_path).name
             if not key_path_obj.is_file():
                 raise FileNotFoundError(
-                    f"ERROR: SSH Key {key_path} could not be found OR it is not a regular file."
+                    f"ERROR: SSH Key {key_path_obj} could not be found OR it is not a regular file."
                 )
             self.key_path = str(key_path_obj)
 

--- a/src/sshconfig_to_ananta/main.py
+++ b/src/sshconfig_to_ananta/main.py
@@ -37,7 +37,7 @@ def parse_arguments():
     parser.add_argument(
         "--relocate",
         help="Relocate the SSH directory to the specified path. (for the container use cases)",
-        default="",
+        default=None,
         type=Path,
     )
     parser.add_argument(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Clearer error message when a relocated key file is missing, now showing the resolved path to aid troubleshooting.
  * Improved handling of the --relocate option by using a null default instead of an empty string, preventing ambiguity when not provided. No behavior change when omitted.

* Chores
  * Version bumped to 2.1.1.

* Tests
  * Added extensive unit tests for host parsing/validation and CLI argument/output behaviors, including TOML/plaintext output and relocation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->