### PR TITLE
ci: pypi-publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,22 @@
+name: Publish to PyPI
+permissions: {}
+
+on:
+  workflow_dispatch:
+
+jobs:
+  pypi-publish:
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: pypi
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - uses: pdm-project/setup-pdm@94a823180e06fcde4ad29308721954a521c96ed0 # v4.4
+      - name: Publish package distributions to PyPI
+        run: pdm publish --repository pypi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual CI workflow to automate publishing the Python package to PyPI using PDM, improving release reliability and consistency.
  * Streamlines and secures the release process via authenticated, repeatable publishing.
  * No changes to application behavior or public interfaces; no impact on end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->