### PR TITLE
temp fix: build py3 image which has python env aligned to Debian 12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 FROM ghcr.io/astral-sh/uv:latest AS distroless-uv
-FROM mirror.gcr.io/icecodexi/python:debian-nonroot AS uv
+FROM mirror.gcr.io/icecodexi/python:debian12-nonroot AS uv
 COPY --link --from=distroless-uv /uv /uvx \
     /usr/local/bin/
 ENV PATH="/home/nonroot/.local/bin:${PATH}" \


### PR DESCRIPTION
Since gcr.io/distroless/python3 are not ready for Debian 13