### PR TITLE
fix: resolve ruff lint violations and eliminate `Any`/type bypass

### DIFF
--- a/src/sshconfig_to_ananta/ananta_host.py
+++ b/src/sshconfig_to_ananta/ananta_host.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 # pyright: strict
 
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from pathlib import Path
-from typing import Any, Iterator, List, Literal, Optional, overload
+from typing import TypeAlias
+
+HostValue: TypeAlias = str | int | list[str]
 
 
-class AnantaHost(Mapping[str, Any]):
+class AnantaHost(Mapping[str, HostValue]):
     """Represents an Ananta host entry.
 
     This class stores the configuration details for connecting to a host
@@ -35,7 +37,7 @@ class AnantaHost(Mapping[str, Any]):
     port: int
     username: str
     key_path: str
-    tags: List[str]
+    tags: list[str]
 
     def __init__(
         self,
@@ -44,8 +46,8 @@ class AnantaHost(Mapping[str, Any]):
         port: str,
         username: str,
         key_path: str,
-        tags: List[str],
-        relocate: Optional[Path],
+        tags: list[str],
+        relocate: Path | None,
     ):
         if not alias:
             raise ValueError("ERROR: alias cannot be empty.")
@@ -86,25 +88,7 @@ class AnantaHost(Mapping[str, Any]):
             "tags": self.tags,
         }
 
-    @overload
-    def __getitem__(self, key: Literal["alias"]) -> str: ...
-
-    @overload
-    def __getitem__(self, key: Literal["ip"]) -> str: ...
-
-    @overload
-    def __getitem__(self, key: Literal["port"]) -> int: ...
-
-    @overload
-    def __getitem__(self, key: Literal["username"]) -> str: ...
-
-    @overload
-    def __getitem__(self, key: Literal["key_path"]) -> str: ...
-
-    @overload
-    def __getitem__(self, key: Literal["tags"]) -> List[str]: ...
-
-    def __getitem__(self, key: str) -> Any:
+    def __getitem__(self, key: str) -> HostValue:
         return self._data[key]
 
     def __iter__(self) -> Iterator[str]:
@@ -125,6 +109,6 @@ class AnantaHost(Mapping[str, Any]):
             parts.append(":".join(self.tags))
         return ",".join(parts) + "\n"
 
-    def dump_host_info(self) -> Mapping[str, Any]:
+    def dump_host_info(self) -> Mapping[str, HostValue]:
         host_info = {k: v for k, v in self._data.items() if k != "alias" and v}
         return host_info

--- a/src/sshconfig_to_ananta/main.py
+++ b/src/sshconfig_to_ananta/main.py
@@ -61,8 +61,8 @@ def main():
     # ssh_path will be valided in convert_to_ananta_hosts()
     try:
         ananta_hosts = convert_to_ananta_hosts(ssh_path, relocate)
-    except Exception:  # noqa: BLE001
-        logger.error("Failed to convert SSH config to Ananta hosts")
+    except Exception:
+        logger.exception("Failed to convert SSH config to Ananta hosts")
         sys.exit(1)
 
     try:

--- a/src/sshconfig_to_ananta/main.py
+++ b/src/sshconfig_to_ananta/main.py
@@ -6,11 +6,12 @@ import logging
 import sys
 from pathlib import Path
 from types import ModuleType
-from typing import Optional
 
 from sshconfig_to_ananta.ssh_config_converter import convert_to_ananta_hosts
 
-tomli_w: Optional[ModuleType] = None
+logger = logging.getLogger(__name__)
+
+tomli_w: ModuleType | None = None
 try:
     import tomli_w
 except ImportError:
@@ -60,8 +61,8 @@ def main():
     # ssh_path will be valided in convert_to_ananta_hosts()
     try:
         ananta_hosts = convert_to_ananta_hosts(ssh_path, relocate)
-    except Exception as e:
-        logging.error("Failed to convert SSH config to Ananta hosts: %s", e)
+    except Exception:  # noqa: BLE001
+        logger.error("Failed to convert SSH config to Ananta hosts")
         sys.exit(1)
 
     try:
@@ -76,9 +77,9 @@ def main():
                 file.writelines(
                     host.dump_comma_separated_str() for host in ananta_hosts
                 )
-        logging.info("Successfully wrote Ananta hosts to %s.", server_list)
-    except Exception as e:
-        logging.exception("Failed to write to %s: %s", server_list, e)
+        logger.info("Successfully wrote Ananta hosts to %s.", server_list)
+    except Exception:
+        logger.exception("Failed to write to %s", server_list)
         raise
 
 

--- a/src/sshconfig_to_ananta/ssh_config_converter.py
+++ b/src/sshconfig_to_ananta/ssh_config_converter.py
@@ -3,27 +3,28 @@
 
 import logging
 import re
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Iterator, List, Optional, Tuple
 
 from sshconfig_to_ananta.ananta_host import AnantaHost
+
+logger = logging.getLogger(__name__)
 
 
 def _read_ssh_config(ssh_path: Path) -> Iterator[str]:
     try:
         with open(ssh_path, "r", encoding="utf-8") as file:
-            for line in file:
-                yield line
+            yield from file
     except FileNotFoundError:
-        logging.warning(
+        logger.warning(
             f"SSH config file could not be found in: {ssh_path}, hosts file could not be generated. "
             "To proceed, make sure you have provided a valid hosts file. "
         )
-    except Exception as e:
-        logging.error(f"Failed to read SSH config file at {ssh_path}: {e}")
+    except Exception:  # noqa: BLE001
+        logger.error(f"Failed to read SSH config file at {ssh_path}")
 
 
-def _parse_valid_line(line: str) -> Optional[Tuple[str, str]]:
+def _parse_valid_line(line: str) -> tuple[str, str] | None:
     ananta_tags_pattern = re.compile(r"^\s+#tags\s+", re.IGNORECASE)
     comment_pattern = re.compile(r"\s*#.*")
     skip_pattern = re.compile(r"^\s*[#$]")
@@ -45,22 +46,20 @@ def _valid_host(alias: str) -> bool:
     return "*" not in alias and bool(alias.strip())
 
 
-def _host_disabled(tags: List[str]) -> bool:
+def _host_disabled(tags: list[str]) -> bool:
     return any(tag.startswith("!ananta") for tag in tags)
 
 
 def _process_proxy_warning(alias: str) -> str:
-    logging.warning(
+    logger.warning(
         f"SSH host {alias} is configured with ProxyCommand/ProxyJump. "
         "Ananta does not support these configurations currently, which may prevent you from connecting to this host. "
     )
     return f"{alias}-needs-proxy"
 
 
-def convert_to_ananta_hosts(
-    ssh_path: Path, relocate: Optional[Path]
-) -> List[AnantaHost]:
-    ananta_hosts: List[AnantaHost] = []
+def convert_to_ananta_hosts(ssh_path: Path, relocate: Path | None) -> list[AnantaHost]:
+    ananta_hosts: list[AnantaHost] = []
     ssh_lines = _read_ssh_config(ssh_path)
 
     found_header_host = False

--- a/src/sshconfig_to_ananta/ssh_config_converter.py
+++ b/src/sshconfig_to_ananta/ssh_config_converter.py
@@ -20,8 +20,8 @@ def _read_ssh_config(ssh_path: Path) -> Iterator[str]:
             f"SSH config file could not be found in: {ssh_path}, hosts file could not be generated. "
             "To proceed, make sure you have provided a valid hosts file. "
         )
-    except Exception:  # noqa: BLE001
-        logger.error(f"Failed to read SSH config file at {ssh_path}")
+    except Exception:
+        logger.exception(f"Failed to read SSH config file at {ssh_path}")
 
 
 def _parse_valid_line(line: str) -> tuple[str, str] | None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -207,7 +207,7 @@ class TestMain(unittest.TestCase):
         mock_convert.return_value = []
 
         # Mock open to raise an exception
-        mock_file.side_effect = IOError("Write failed")
+        mock_file.side_effect = OSError("Write failed")
 
         # Create a temporary file for testing
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
@@ -216,9 +216,8 @@ class TestMain(unittest.TestCase):
         try:
             # Mock sys.argv
             test_args = ["main.py", str(temp_path)]
-            with patch.object(sys, "argv", test_args):
-                with self.assertRaises(IOError):
-                    main()
+            with patch.object(sys, "argv", test_args), self.assertRaises(OSError):
+                main()
 
         finally:
             # Clean up
@@ -234,9 +233,11 @@ class TestMain(unittest.TestCase):
         try:
             # Mock sys.argv with non-existent relocate path
             test_args = ["main.py", "--relocate", "/nonexistent/path", str(temp_path)]
-            with patch.object(sys, "argv", test_args):
-                with self.assertRaises(FileNotFoundError):
-                    main()
+            with (
+                patch.object(sys, "argv", test_args),
+                self.assertRaises(FileNotFoundError),
+            ):
+                main()
 
         finally:
             # Clean up
@@ -290,9 +291,11 @@ class TestMain(unittest.TestCase):
         try:
             # Mock sys.argv with file path as relocate
             test_args = ["main.py", "--relocate", str(temp_path), str(output_path)]
-            with patch.object(sys, "argv", test_args):
-                with self.assertRaises(NotADirectoryError):
-                    main()
+            with (
+                patch.object(sys, "argv", test_args),
+                self.assertRaises(NotADirectoryError),
+            ):
+                main()
 
         finally:
             # Clean up
@@ -338,7 +341,7 @@ class TestMain(unittest.TestCase):
 
         # Remove tomli_w from sys.modules if it exists
         original_modules = sys.modules.copy()
-        modules_to_remove = [k for k in sys.modules.keys() if "tomli" in k]
+        modules_to_remove = [k for k in sys.modules if "tomli" in k]
         for module in modules_to_remove:
             if module in sys.modules:
                 del sys.modules[module]

--- a/tests/test_main_module.py
+++ b/tests/test_main_module.py
@@ -12,17 +12,18 @@ class TestMainModule(unittest.TestCase):
         # Mock sys.argv with test arguments
         test_args = ["__main__.py", "test_output.csv"]
 
-        with patch.object(sys, "argv", test_args):
-            # Mock the main function to avoid actual execution
-            with patch("sshconfig_to_ananta.main.main", return_value=None) as mock_main:
-                # Import the __main__ module - this should not execute main()
-                # because __name__ won't be "__main__" when imported as a module
-                import sshconfig_to_ananta.__main__
+        with (
+            patch.object(sys, "argv", test_args),
+            patch("sshconfig_to_ananta.main.main", return_value=None) as mock_main,
+        ):
+            # Import the __main__ module - this should not execute main()
+            # because __name__ won't be "__main__" when imported as a module
+            import sshconfig_to_ananta.__main__
 
-                # Verify the import worked
-                self.assertTrue(hasattr(sshconfig_to_ananta.__main__, "main"))
-                # main() should not have been called during import
-                mock_main.assert_not_called()
+            # Verify the import worked
+            self.assertTrue(hasattr(sshconfig_to_ananta.__main__, "main"))
+            # main() should not have been called during import
+            mock_main.assert_not_called()
 
     def test_main_module_imports(self):
         """Test that __main__.py can be imported without errors."""

--- a/tests/test_ssh_config_converter.py
+++ b/tests/test_ssh_config_converter.py
@@ -53,7 +53,9 @@ class TestSSHConfigConverter(unittest.TestCase):
         self.assertEqual(_process_proxy_warning(alias), "myserver-needs-proxy")
 
     def test_convert_to_ananta_hosts(self):
-        with tempfile.NamedTemporaryFile(mode="w+") as temp_ssh_config:
+        with tempfile.NamedTemporaryFile(
+            mode="w", delete=False, suffix=".config"
+        ) as temp_ssh_config:
             temp_ssh_config.write("""
 Host minimum_config
     HostName 192.168.1.100
@@ -86,7 +88,12 @@ Host Disabled-Host--Must-at-Last
 """)
 
             temp_ssh_config.flush()
-            hosts = convert_to_ananta_hosts(Path(temp_ssh_config.name), None)
+            ssh_config_path = Path(temp_ssh_config.name)
+
+        try:
+            hosts = convert_to_ananta_hosts(ssh_config_path, None)
+        finally:
+            ssh_config_path.unlink(missing_ok=True)
 
         self.assertEqual(len(hosts), 4)
 

--- a/tests/test_ssh_config_converter.py
+++ b/tests/test_ssh_config_converter.py
@@ -53,8 +53,8 @@ class TestSSHConfigConverter(unittest.TestCase):
         self.assertEqual(_process_proxy_warning(alias), "myserver-needs-proxy")
 
     def test_convert_to_ananta_hosts(self):
-        temp_ssh_config = tempfile.NamedTemporaryFile(mode="w+")
-        temp_ssh_config.write("""
+        with tempfile.NamedTemporaryFile(mode="w+") as temp_ssh_config:
+            temp_ssh_config.write("""
 Host minimum_config
     HostName 192.168.1.100
 
@@ -85,9 +85,9 @@ Host Disabled-Host--Must-at-Last
     #tags dummy,!ananta,test
 """)
 
-        temp_ssh_config.flush()
-        hosts = convert_to_ananta_hosts(Path(temp_ssh_config.name), None)
-        temp_ssh_config.close()
+            temp_ssh_config.flush()
+            hosts = convert_to_ananta_hosts(Path(temp_ssh_config.name), None)
+
         self.assertEqual(len(hosts), 4)
 
         minimum_config = [host for host in hosts if host.alias == "minimum_config"]
@@ -152,13 +152,15 @@ Host Disabled-Host--Must-at-Last
         from unittest.mock import patch
 
         # Create a mock file that raises an exception
-        with patch(
-            "sshconfig_to_ananta.ssh_config_converter.open",
-            side_effect=Exception("Permission denied"),
+        with (
+            patch(
+                "sshconfig_to_ananta.ssh_config_converter.open",
+                side_effect=Exception("Permission denied"),
+            ),
+            self.assertLogs(level="ERROR") as log,
         ):
-            with self.assertLogs(level="ERROR") as log:
-                result = list(_read_ssh_config(Path("/some/path")))
-                self.assertEqual(len(result), 0)
+            result = list(_read_ssh_config(Path("/some/path")))
+            self.assertEqual(len(result), 0)
 
         # Check that error was logged
         self.assertTrue(any("Failed to read SSH config file" in m for m in log.output))


### PR DESCRIPTION
## Summary

Resolve all Ruff lint violations reported by CI and clean up `Any` type bypasses from the code.

## Changes

### Lint fixes
- Update deprecated type annotations: `List`→`list`, `Optional[X]`→`X | None`, `Tuple`→`tuple`, `Iterator` from `collections.abc`
- Replace root logger calls with module-level loggers (`logging.xxx`→`logger.xxx`)
- Fix `TRY401` (redundant exception object in logging) by switching to `logger.exception`, which also preserves stack traces for crash diagnosis
- Replace `yield` loop with `yield from` (UP028)

### Type safety cleanup
- Define `HostValue` type alias to replace `Any` in the `AnantaHost` Mapping
- Remove `@overload` stubs on `__getitem__` — plain `Mapping[str, HostValue]` is correct and passes strict `ty` checks
- Update `__getitem__` and `dump_host_info` return types to use `HostValue`

### Test fixes
- `IOError`→`OSError`
- Combine nested `with` statements (parenthesized context managers)
- `.keys()`→direct dict iteration
- Use `NamedTemporaryFile` as a context manager with `delete=False` + explicit cleanup in `finally` for cross-platform (Windows) compatibility

## Verification

- `ruff check`: All checks passed
- `ruff format`: Formatted
- `ty check`: All checks passed
- `pytest`: 43 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and reporting of SSH configuration conversion and file-writing errors.
  * Preserved detailed diagnostics for write failures while keeping general read and conversion messages concise.

* **Refactor**
  * Improved type safety and consistency across SSH configuration processing.
  * Updated internal handling to use modern Python conventions without changing expected functionality.

* **Tests**
  * Strengthened coverage for conversion failures, file operations, and command-line entry-point behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
