### PR TITLE
fix(ci): run one CI suite for Renovate PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,11 +11,18 @@ on:
     pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   build:
+    # Same-repository Renovate PRs use the checks from the push run for the
+    # identical SHA. Fork PRs still need pull_request checks because their
+    # branches do not produce push events in this repository.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository ||
+      !startsWith(github.head_ref, 'renovate/')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -39,14 +46,19 @@ jobs:
       uses: reviewdog/action-hadolint@2d0eb7c86a0ddd94eb625485f4cc2730e105edd8 # v1.53.0
       with:
         hadolint_ignore: DL3007 SC2114
-        reporter: github-check
+        # A new push branch has no pull-request diff for reviewdog to filter,
+        # so report annotations only from pull_request runs. The action still
+        # executes hadolint in the authoritative Renovate push job.
+        reporter: ${{ github.event_name == 'pull_request' && 'github-check' || 'local' }}
+        filter_mode: ${{ github.event_name == 'pull_request' && 'added' || 'nofilter' }}
 
     # misspell
     - name: misspell
       uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962 # v1.27.0
       with:
         locale: "US"
-        reporter: github-check
+        reporter: ${{ github.event_name == 'pull_request' && 'github-check' || 'local' }}
+        filter_mode: ${{ github.event_name == 'pull_request' && 'added' || 'nofilter' }}
     # AutoCorrect
     - name: AutoCorrect
       uses: huacnlee/autocorrect-action@bf91ab3904c2908dd8e71312a8a83ed1eb632997 # main

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,11 +21,15 @@ on:
       - 'pyproject.toml'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
   test:
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository ||
+      !startsWith(github.head_ref, 'renovate/')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -45,6 +49,10 @@ jobs:
         python3 -m unittest discover -s tests
 
   coverage:
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository ||
+      !startsWith(github.head_ref, 'renovate/')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

- limit `push` CI to `master` and `renovate/**`, while ordinary same-repository and fork PRs continue to use `pull_request`
- skip Linter and Unittest jobs only for same-repository `renovate/**` pull requests; their identical-SHA push jobs remain authoritative
- isolate concurrency by event so push and pull-request workflow records cannot cancel one another
- preserve fork coverage and avoid hard-coding any short-lived PR branch
- keep reviewdog annotations on PR events while using local/no-filter reporting on authoritative push runs, avoiding branch-creation diff failures

## Why

A same-repository Renovate branch emits both `push` and `pull_request` events. Event-qualified concurrency groups stop cross-event cancellation, but by themselves still execute two complete CI suites. Renovate is configured with `automergeType: branch`, so the branch's push checks must survive and complete. The pull-request workflow records remain visible, but their substantive jobs are skipped only when the PR head belongs to this repository and its branch starts with `renovate/`.

The repository ruleset does not name required status-check contexts; it requires CodeQL and PR policy. Existing job names (`build`, the Python matrix, and `coverage`) are therefore preserved rather than copied from another repository.

## Verification

Local gates before the signed amended commit:

- `git diff --check`
- `prek run --all-files` (actionlint and Gitleaks pass; only the pre-existing informational zizmor `superfluous-actions` finding in `ananta.yml` remains)
- `uv run --with pytest --with pytest-cov -- pytest --cov --cov-branch --cov-report=xml` (43 passed)

Real GitHub event test (temporary PR #200, branch `renovate/ci-event-routing-test-198-v2`, exact test SHA `54675cad3f69e9fcf385f4c3464612b04e14bf9d`):

- push Linter run 32558684384: `build` succeeded
- push Unittest run 32558684404: `coverage` and all 10 Python/OS matrix jobs succeeded
- pull_request Linter run 32558687037: `build` skipped
- pull_request Unittest run 32558687098: `test` and `coverage` skipped
- CodeQL run 32558685155 succeeded; Codecov project/patch checks succeeded
- no check failed and no run was cancelled; the exact SHA had the successful push contexts required by Renovate branch automerge

The temporary PR was closed without merging and its branch deleted after evidence collection.
